### PR TITLE
add build dependencies to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython", "numpy"]


### PR DESCRIPTION
This lets people pip install from a clean environment without first having to pip install numpy and cython